### PR TITLE
fix install button

### DIFF
--- a/static/index.md
+++ b/static/index.md
@@ -8,4 +8,4 @@ You can use the button below to install the pre-built firmware directly to your 
 
 <esp-web-install-button manifest="./manifest.json"></esp-web-install-button>
 
-<script type="module" src="https://unpkg.com/esp-web-tools@9.1.0/dist/web/install-button.js?module"></script>
+<script type="module" src="https://unpkg.com/esp-web-tools@9/dist/web/install-button.js?module"></script>


### PR DESCRIPTION
the version 9.1.0 does not work so removing the 1.0 goes to the latest version as the esphome instruction page descibed to do