### PR TITLE
Do not pin specific minor or patch versions of GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,14 +33,14 @@ jobs:
           - dev
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v4
       - name: ESPHome ${{ matrix.esphome-version }}
-        uses: esphome/build-action@v7.0.0
+        uses: esphome/build-action@v7
         with:
           yaml-file: ${{ matrix.file }}.yaml
           version: ${{ matrix.esphome-version }}
       - name: ESPHome ${{ matrix.esphome-version }} Factory
-        uses: esphome/build-action@v7.0.0
+        uses: esphome/build-action@v7
         with:
           yaml-file: ${{ matrix.file }}.factory.yaml
           version: ${{ matrix.esphome-version }}

--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -28,25 +28,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v4
 
       - run: mkdir -p output/firmware
 
       - name: Build
-        uses: actions/jekyll-build-pages@v1.0.13
+        uses: actions/jekyll-build-pages@v1
         with:
           source: ./static
           destination: ./output
 
       - name: Fetch firmware files
-        uses: robinraju/release-downloader@v1.12
+        uses: robinraju/release-downloader@v1
         with:
           latest: true
           fileName: '*'
           out-file-path: output/firmware
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3.0.1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: output
           retention-days: 1
@@ -65,8 +65,8 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Setup Pages
-        uses: actions/configure-pages@v5.0.0
+        uses: actions/configure-pages@v5
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4.0.5
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Major versions should guarantee compatibility. This change ensures the latest minor and patch version of GitHub actions is automatically used within the given major, instead of having to accept Dependabot PRs for it all the time. By this, the time needed for a security update of an action to ripple through is also reduced.
