### PR TITLE
Add Release Drafter workflow

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,14 @@
+categories:
+  - title: "Breaking Changes"
+    label: "breaking-change"
+  - title: "Dependencies"
+    collapse-after: 1
+    labels:
+      - "dependencies"
+
+template: |
+  ## What's Changed
+
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_VERSION

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,40 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  release-drafter:
+    name: Release Drafter
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0  # need all tags to compute the next patch
+
+      - name: Compute next version
+        id: version
+        run: |
+          prefix="$(date -u +%y.%-m)"
+          latest="$(git tag --list "${prefix}.*" --sort=-v:refname | head -n1)"
+          if [ -z "$latest" ]; then
+            next="${prefix}.1"
+          else
+            patch="${latest##*.}"
+            next="${prefix}.$((patch + 1))"
+          fi
+          echo "version=$next" >> "$GITHUB_OUTPUT"
+
+      - uses: release-drafter/release-drafter@5de93583980a40bd78603b6dfdcda5b4df377b32  # v7.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag: ${{ steps.version.outputs.version }}
+          name: ${{ steps.version.outputs.version }}


### PR DESCRIPTION
## Summary

- Add `.github/release-drafter.yml` with a minimal categorized changelog config (Breaking Changes, Dependencies) — dependencies collapsed after 1 so Dependabot PRs don't drown the notes.
- Add `.github/workflows/release-drafter.yml` that runs on push to `main`, computes a calver `YY.M.X` tag from the current UTC date plus the highest existing tag for the month (falling back to `.1`), and passes `tag` / `name` to `release-drafter@v7.2.0` (SHA-pinned to match the repo's existing pinning style).

This is the first piece of enabling immutable releases: keeping a draft release up-to-date means a future build workflow can attach firmware artifacts to the draft before it's published, so publishing only runs the post-build steps.

## Test plan

- [ ] Merge and confirm the workflow runs on the next push to `main`.
- [ ] Check the Releases page — expect a draft named `26.4.1` (first April 2026 release), categorized as above.
- [ ] Further merges in the same month should keep updating the same draft rather than creating new ones.
- [ ] Publishing the draft should continue to trigger `publish-firmware.yml` on the `release:published` event as it does today.