### PR TITLE
Replace robinraju/release-downloader with gh CLI

### DIFF
--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -39,11 +39,9 @@ jobs:
           destination: ./output
 
       - name: Fetch firmware files
-        uses: robinraju/release-downloader@28fc21f50d76778e7023361aa1f863e717d3d56f  # v1.13
-        with:
-          latest: true
-          fileName: '*'
-          out-file-path: output/firmware
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release download --pattern '*' --dir output/firmware
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5.0.0


### PR DESCRIPTION
## Summary

- Drops the third-party `robinraju/release-downloader` action from `publish-pages.yml`.
- Replaces it with `gh release download --pattern '*' --dir output/firmware`, using the pre-installed `gh` CLI on `ubuntu-latest`.
- Same behavior — fetches every asset from the latest release into `output/firmware` — with one less dependency tracked by Dependabot.

## Test plan

- [ ] CI runs `Publish Pages` on this PR and the firmware files land in `output/firmware` as before.
- [ ] After merge, the next `workflow_run` trigger publishes pages successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)